### PR TITLE
fix ready listener not triggering when using a feed which is already ready

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ class MountableHypertrie extends EventEmitter {
       if (!opts.secretKey) feed = this.corestore.default({ key, ...this.opts })
       feed = this.corestore.get({ key, discoverable: true, ...this.opts })
     }
-    feed.once('ready', () => this.emit('feed', feed))
+    feed.ready(() => this.emit('feed', feed))
 
     this.trie = opts.trie || hypertrie(null, {
       ...opts,


### PR DESCRIPTION
I found the issue when investigating https://github.com/mafintosh/hyperdrive/issues/241.

When we checkout a new hypertrie, a new `MountableHypertrie` is created and a new `ready` listeners is attached on the feed. However, when the feed is already ready, the `once` callback will never be called. 

Changing it to `ready(cb)` will make sure the callback will always be triggered.