### PR TITLE
ensure parent is ready when creating subtrie

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,6 +72,8 @@ class MountableHypertrie extends EventEmitter {
   }
 
   _createHypertrie (key, opts, cb) {
+    // Ensure the parent key is available.
+    if (!this.key) return this.ready(() => this._createHypertrie(key, opts, cb))
     const self = this
 
     const keyString = key.toString('hex')


### PR DESCRIPTION
I run into a situation where a subtrie is being created (as response to creating or opening a mount, through hyperdrive) while `this.key` is not yet set, which means `ready` thunk has not completed.

The problem is - as things are currently this is hard to recover, becaues the corestore will record wrong dependencies for the cores of the subtries, which makes them not replicate with the parent.

Here it is ensured that the trie has a key before opening subtries.