### PR TITLE
Fix path.posix not being available in browsers

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-const p = require('path').posix
+const pathRoot = require('path')
+const p = pathRoot.posix || pathRoot
 const { EventEmitter } = require('events')
 
 const hypertrie = require('hypertrie')


### PR DESCRIPTION
`path-browserify` does not provide a `.posix` implementation.

Environments without a posix implementation should just use the native implementation.