### PR TITLE
Add header type option for configuring the feed header type

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ class MountableHypertrie extends Nanoresource {
     this.discoveryKey = this.key ? hypercoreCrypto.discoveryKey(this.key) : null
     this.opts = opts
     this.sparse = opts.sparse !== false
+    this.headerType = opts.headerType || 'mountable-hypertrie'
 
     if (opts.valueEncoding) throw new Error('MountableHypertrie does not currently support a valueEncoding option.')
 
@@ -43,7 +44,8 @@ class MountableHypertrie extends Nanoresource {
         feed,
         version: null,
         alwaysUpdate: true,
-        alwaysReconnect: true
+        alwaysReconnect: true,
+        headerType: this.headerType
       })
       this.trie.feed[OWNER] = this.trie
     }

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ class MountableHypertrie extends Nanoresource {
     this.discoveryKey = this.key ? hypercoreCrypto.discoveryKey(this.key) : null
     this.opts = opts
     this.sparse = opts.sparse !== false
-    this.headerSubtype = opts.headerSubtype || 'mountable-hypertrie'
+    this.subtype = opts.subtype || 'mountable-hypertrie'
 
     if (opts.valueEncoding) throw new Error('MountableHypertrie does not currently support a valueEncoding option.')
 
@@ -45,7 +45,7 @@ class MountableHypertrie extends Nanoresource {
         version: null,
         alwaysUpdate: true,
         alwaysReconnect: true,
-        headerSubtype: this.headerSubtype
+        subtype: this.subtype
       })
       this.trie.feed[OWNER] = this.trie
     }

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ class MountableHypertrie extends Nanoresource {
     this.discoveryKey = this.key ? hypercoreCrypto.discoveryKey(this.key) : null
     this.opts = opts
     this.sparse = opts.sparse !== false
-    this.headerType = opts.headerType || 'mountable-hypertrie'
+    this.headerSubtype = opts.headerSubtype || 'mountable-hypertrie'
 
     if (opts.valueEncoding) throw new Error('MountableHypertrie does not currently support a valueEncoding option.')
 
@@ -45,7 +45,7 @@ class MountableHypertrie extends Nanoresource {
         version: null,
         alwaysUpdate: true,
         alwaysReconnect: true,
-        headerType: this.headerType
+        headerSubtype: this.headerSubtype
       })
       this.trie.feed[OWNER] = this.trie
     }


### PR DESCRIPTION
This will differentiate mountable hypertries from regular hypertries at the Header level.

Also makes the header configurable in for higher level data structures.

Related to https://github.com/hypercore-protocol/hyperdrive/issues/294